### PR TITLE
locator failure in main branch

### DIFF
--- a/cypress/integration/hometest.spec.js
+++ b/cypress/integration/hometest.spec.js
@@ -28,7 +28,7 @@ describe("Home", () => {
             .click()
             // Cypress occasionally moves too quick and checks before the text value has updated in the UI
             .wait(1000);
-          cy.get(".attempts")
+          cy.get(".attempt")
             // `cy.should('have.text', foo)` compares the text of the element yielded in `cy.get()` to the expected, in this example `foo`
             .should("have.text", expected);
         });


### PR DESCRIPTION
In the latest discussions we came to the conclusion to have the errors already included to reduce setup time before interviews.

This change introduced the locator error on line 31 which in hometest.spec.js is the first part of the interview.

important note:
compared to testcafe this is the latter occurrence of the locator, I believe this is a more straight forward entry for the candidate to recognize what is wrong but curious there about feedback.